### PR TITLE
fix: dynamic navigation path

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,9 @@
+const basePath = new URL(document.currentScript.src, window.location.href)
+  .pathname.replace(/assets\/js\/main\.js$/, '');
+
 async function buildMenu() {
   try {
-    const response = await fetch('/content/nav.json');
+    const response = await fetch(`${basePath}content/nav.json`);
     const items = await response.json();
     const nav = document.getElementById('site-nav');
     const ul = document.createElement('ul');


### PR DESCRIPTION
## Summary
- compute repository base path from script source
- fetch nav.json using calculated prefix

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adbc06dc38832c8a268a7900ea6c37